### PR TITLE
fixed custom "MQTT Topic Format" and newer phpMQTT.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -154,6 +154,8 @@ $(document).ready(function() {
     </thead>
     <tbody>
 <?php
+	$github_tasmota_release_data = getGithubTasmotaReleaseData();
+
     $list_model='';
     $now=time();
     $lastbackup_green=0;
@@ -210,8 +212,22 @@ $(document).ready(function() {
             $ver=substr($version,0,$pos);
             $tag=substr($version,$pos);
             $version=$ver.' <small>'.$tag.'</small>';
+
+			$release_html_url = "";
+			if ( $tag == "(tasmota)" ) {
+				$github_tag_name = 'v' . $ver;
+				foreach ( $github_tasmota_release_data as $release => $values ) {
+					$release_html_url = $values['html_url'];
+					if ( $values['tag_name'] == $github_tag_name ) {
+						break;
+					}
+				}
+			} else {
+				// default to the Tasmota documentation if a custom "version" is in use
+				$release_html_url = "https://tasmota.github.io/docs/";
+			}
         }
-	echo "</center></td><td><center>" . $version . "</center></td><td $color><center>" . $lastbackup . "</center></td>";
+	echo "</center></td><td><center><a href='" . $release_html_url . "'>" . $version . "</a></center></td><td $color><center>" . $lastbackup . "</center></td>";
 	echo "<td><center><form method='POST' action='listbackups.php'><input type='hidden' value='" . $name . "' name='name'><input type='hidden' value='" . $id . "' name='id'><input type='submit' value='" . $numberofbackups . "' class='btn-xs btn-info'></form></center></td>";
 	echo "<td><center><form method='POST' action='index.php'><input type='hidden' value='" . $ip . "' name='ip'><input type='hidden' value='singlebackup' name='task'><input type='submit' value='Backup' class='btn-xs btn-success'></form></center></td>";
 	echo "<td><center><form method='POST' action='edit.php'><input type='hidden' value='" . $ip . "' name='ip'><input type='hidden' value='" . $name . "' name='name'><input type='hidden' value='edit' name='task'><input type='submit' value='Edit' class='btn-xs btn-warning'></form></center></td>";

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -544,3 +544,43 @@ function TBFooter()
 <?php
 }
 
+function getGithubTasmotaReleaseData()
+{
+    global $settings;
+
+	// put the releases json in the backup_folder
+    $backupfolder = $settings['backup_folder'];
+	$get_new_version = false;
+
+	$github_tasmota_release_data_file = $backupfolder . "/github-tasmota-release-data.json";
+	// check if file exists
+	if ( file_exists($github_tasmota_release_data_file) === true ) {
+		$_mtime = filemtime($github_tasmota_release_data_file);
+		$yesterday = strtotime("-1 days");
+		if ( $_mtime <= $yesterday ) {
+			$get_new_version = true;
+		}
+	} else {
+		$get_new_version = true;
+	}
+
+	if ( $get_new_version ) {
+		// get Tasmota release data from github - but only if it is the next calendar day
+		$opts = [
+			'http' => [
+				'method' => 'GET',
+				'header' => [
+					'User-Agent: PHP'
+				]
+			]
+		];
+		$context = stream_context_create($opts);
+		$github_tasmota_version_release_details = file_get_contents("https://api.github.com/repos/arendst/Tasmota/releases", false, $context);
+		file_put_contents($github_tasmota_release_data_file, $github_tasmota_version_release_details);
+	} else {
+		$github_tasmota_version_release_details = file_get_contents($github_tasmota_release_data_file);
+	}
+	$github_tasmota_release_data = json_decode($github_tasmota_version_release_details, true);
+
+	return $github_tasmota_release_data;
+}

--- a/lib/mqtt.inc.php
+++ b/lib/mqtt.inc.php
@@ -3,21 +3,28 @@
 require_once(__DIR__.'/phpMQTT.php');
 
 
-GLOBAL $mqtt_found;
-$mqtt_found=[];
+global $mqtt_found;
 
 function setupMQTT($server, $port=1883, $user, $password)
 {
-    $mqtt = new phpMQTT($server, $port, 'TasmoBackup');
+	global $mqtt_found;
+
+	$mqtt_found = array();
+    $mqtt = new Bluerhinos\phpMQTT($server, $port, 'TasmoBackup');
+
+	// turn on debugging
+//	$mqtt->debug = true;
 
     if(!$mqtt->connect(true, NULL, $user, $password))
         return false;
+
     return $mqtt;
 }
 
-function getTasmotaMQTTScan($mqtt,$topic,$user=false,$password=false,$slim=false)
+// what on earth does the $slim parameter mean?
+function getTasmotaMQTTScan($mqtt, $topic, $user=false, $password=false, $slim=false)
 {
-    GLOBAL $mqtt_found,$settings;
+    global $mqtt_found, $settings;
 
     $topics['+/stat/STATUS'] = array('qos' => 0, 'function' => 'collectMQTTStatus');
     $topics['+/stat/STATUS2'] = array('qos' => 0, 'function' => 'collectMQTTStatus2');
@@ -26,76 +33,78 @@ function getTasmotaMQTTScan($mqtt,$topic,$user=false,$password=false,$slim=false
     $topics['stat/+/STATUS2'] = array('qos' => 0, 'function' => 'collectMQTTStatus2');
     $topics['stat/+/STATUS5'] = array('qos' => 0, 'function' => 'collectMQTTStatus5');
 
-    if(isset($settings['mqtt_topic_format'])) {
-        $custom_topic=str_replace(array('%prefix%','%topic%'),array('stat','+'),$settings['mqtt_topic_format']);
+    if (isset($settings['mqtt_topic_format'])) {
+        $custom_topic = str_replace(array('%prefix%','%topic%'), array('stat','+'), $settings['mqtt_topic_format']);
         $topics[$custom_topic.'/STATUS'] = array('qos' => 0, 'function' => 'collectMQTTStatus');
         $topics[$custom_topic.'/STATUS2'] = array('qos' => 0, 'function' => 'collectMQTTStatus2');
         $topics[$custom_topic.'/STATUS5'] = array('qos' => 0, 'function' => 'collectMQTTStatus5');
     }
-    $mqtt->subscribe($topics);
+    $mqtt->subscribe($topics, $qos = 0);
 
-    for($i=0; $i<1000; $i++) {
-        if($i==10 && !$slim) {
-            // HomeAssistant swapped
-            $mqtt->publish($topic.'/cmnd/STATUS','0');
-            if($topic=='tasmotas')
-                $mqtt->publish('sonoffs/cmnd/STATUS','0');
-        }
-        if($i==60 && !$slim) {
-            if(isset($settings['mqtt_topic_format'])) {
-                $mqtt->publish(str_replace(array('%prefix%','%topic%'),array('stat',$topic),$settings['mqtt_topic_format']).'/STATUS','0');
-                if($topic=='tasmotas')
-                    $mqtt->publish(str_replace(array('%prefix%','%topic%'),array('stat','sonoffs'),$settings['mqtt_topic_format']).'/STATUS','0'); 
-            }
-        }
-        if($i==110 && !$slim) {
-            $mqtt->publish('cmnd/'.$topic.'/STATUS','0');
-            if($topic=='tasmotas')
-                $mqtt->publish('cmnd/sonoffs/STATUS','0');
-        }
+	// HomeAssistant swapped
+	$mqtt->publish($topic.'/cmnd/STATUS','0');
+	if ($topic == 'tasmotas')
+		$mqtt->publish('sonoffs/cmnd/STATUS','0');
+	if (isset($settings['mqtt_topic_format'])) {
+		$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd', $topic), $settings['mqtt_topic_format']);
+		$mqtt->publish($topic_prefix . '/STATUS','0');
+		if($topic == 'tasmotas')
+			$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd','sonoffs'), $settings['mqtt_topic_format']);
+			$mqtt->publish($topic_prefix . '/STATUS','0'); 
+	}
+	$mqtt->publish('cmnd/'.$topic.'/STATUS','0');
+	if ($topic == 'tasmotas')
+		$mqtt->publish('cmnd/sonoffs/STATUS','0');
 
-        if($i==210) {
-            // Default
-            $mqtt->publish($topic.'/cmnd/STATUS','5');
-            if($topic=='tasmotas')
-                $mqtt->publish('sonoffs/cmnd/STATUS','5');
-        }
-        if($i==260) {
-            if(isset($settings['mqtt_topic_format'])) {
-                $mqtt->publish(str_replace(array('%prefix%','%topic%'),array('stat',$topic),$settings['mqtt_topic_format']).'/STATUS','5');
-                if($topic=='tasmotas')
-                    $mqtt->publish(str_replace(array('%prefix%','%topic%'),array('stat','sonoffs'),$settings['mqtt_topic_format']).'/STATUS','5');
-            }
-        }
-        if($i==320) {
-            $mqtt->publish('cmnd/'.$topic.'/STATUS','5');
-            if($topic=='tasmotas')
-                $mqtt->publish('cmnd/sonoffs/STATUS','5');
-        }
-        while($mqtt->proc(false)) {};
-        usleep(30000);
-    }
-    $results=[];
+	// Default
+	$mqtt->publish($topic.'/cmnd/STATUS','5');
+	if ($topic == 'tasmotas')
+		$mqtt->publish('sonoffs/cmnd/STATUS','5');
+
+	if(isset($settings['mqtt_topic_format'])) {
+		$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd', $topic), $settings['mqtt_topic_format']);
+		$mqtt->publish($topic_prefix . '/STATUS','5');
+		if($topic == 'tasmotas')
+			$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd','sonoffs'), $settings['mqtt_topic_format']);
+			$mqtt->publish($topic_prefix . '/STATUS','5');
+	}
+
+	$mqtt->publish('cmnd/'.$topic.'/STATUS','5');
+	if($topic == 'tasmotas')
+		$mqtt->publish('cmnd/sonoffs/STATUS','5');
+
+	$start_ts = time();
+	while($mqtt->proc(false)) {
+		$current_ts = time();
+		# if after 5 seconds, then break out and end
+		if ($current_ts - $start_ts >= 5) {
+			break;
+		}
+	}
+
+	$mqtt->close();
+
+    $results = [];
     foreach($mqtt_found as $found) {
         if(isset($found['status5'])) {
-            $status=jsonTasmotaDecode($found['status5']);
+            $status = jsonTasmotaDecode($found['status5']);
             if(isset($status['StatusNET']['IP']))		// < 5.12.0
-                $tmp['ip']=$status['StatusNET']['IP'];
+                $tmp['ip'] = $status['StatusNET']['IP'];
             if(isset($status['StatusNET']['IPAddress']))	// >= 5.12.0
-                $tmp['ip']=$status['StatusNET']['IPAddress'];
+                $tmp['ip'] = $status['StatusNET']['IPAddress'];
             if(isset($status['StatusNET']['Mac']))
-                $tmp['mac']=$status['StatusNET']['Mac'];
+                $tmp['mac'] = $status['StatusNET']['Mac'];
             if(isset($found['status'])) {
-                $status=jsonTasmotaDecode($found['status']);
-                if ($status['Status']['DeviceName'] && strlen(preg_replace('/\s+/', '',$status['Status']['DeviceName']))>0)
-                    $tmp['name']=$status['Status']['DeviceName'];
+                $status = jsonTasmotaDecode($found['status']);
+                if ($status['Status']['DeviceName'] && strlen(preg_replace('/\s+/', '', $status['Status']['DeviceName']))>0)
+                    $tmp['name'] = $status['Status']['DeviceName'];
                 else if ($status['Status']['FriendlyName'][0])
-                    $tmp['name']=$status['Status']['FriendlyName'][0];
+                    $tmp['name'] = $status['Status']['FriendlyName'][0];
             }
-            if (isset($settings['autoadd_scan']) && $settings['autoadd_scan']=='Y') {
+            if (isset($settings['autoadd_scan']) && $settings['autoadd_scan'] == 'Y') {
                 addTasmotaDevice($tmp['ip'], $user, $password);
             } else {
-                $results[]=$tmp;
+                $results[] = $tmp;
             }
         }
     }
@@ -105,51 +114,70 @@ function getTasmotaMQTTScan($mqtt,$topic,$user=false,$password=false,$slim=false
 
 function collectMQTTStatus($topic, $msg)
 {
-    GLOBAL $mqtt_found;
+    global $mqtt_found, $settings;
 
     //Get Name
-    $topics=explode('/',$topic);
-    $name=false;
-    if($topics[0]=='stat')
-        $name=$topics[1];
-    if($topics[1]=='stat')
-        $name=$topics[0];
+    $topics = explode('/', $topic);
+    $name = false;
+	// stat/+ = name is index 1
+	// +/stat = name is index 0
+	// $settings['mqtt_topic_format'] = name is ??
+    if($topics[0] == 'stat') {
+        $name = $topics[1];
+    } elseif($topics[1] == 'stat') {
+        $name = $topics[0];
+	} elseif(isset($settings['mqtt_topic_format'])) {
+		$topic_format_parts = explode('/', $settings['mqtt_topic_format']);
+		$idx = array_search('%topic%', $topic_format_parts);
+		$name = $topics[$idx];
+	}
+
     if($name) {
-        $mqtt_found[$name]['status']=$msg;
+        $mqtt_found[$name]['status'] = $msg;
     }
     return;
 }
 
 function collectMQTTStatus2($topic, $msg)
 {
-    GLOBAL $mqtt_found;
+    global $mqtt_found, $settings;
 
     //Get Version
-    $topics=explode('/',$topic);
-    $name=false;
-    if($topics[0]=='stat')
-        $name=$topics[1];
-    if($topics[1]=='stat')
-        $name=$topics[0];
+    $topics = explode('/', $topic);
+    $name = false;
+    if($topics[0] == 'stat') {
+        $name = $topics[1];
+    } elseif($topics[1] == 'stat') {
+        $name = $topics[0];
+	} elseif(isset($settings['mqtt_topic_format'])) {
+		$topic_format_parts = explode('/', $settings['mqtt_topic_format']);
+		$idx = array_search('%topic%', $topic_format_parts);
+		$name = $topics[$idx];
+	}
     if($name) {
-        $mqtt_found[$name]['status2']=$msg;
+        $mqtt_found[$name]['status2'] = $msg;
     }
     return;
 }
 
 function collectMQTTStatus5($topic, $msg)
 {
-    GLOBAL $mqtt_found;
+    global $mqtt_found, $settings;
 
     //Get IP
-    $topics=explode('/',$topic);
-    $name=false;
-    if($topics[0]=='stat')
-        $name=$topics[1];
-    if($topics[1]=='stat')
-        $name=$topics[0];
+    $topics = explode('/', $topic);
+    $name = false;
+    if($topics[0] == 'stat') {
+        $name = $topics[1];
+    } elseif($topics[1] == 'stat') {
+        $name = $topics[0];
+	} elseif(isset($settings['mqtt_topic_format'])) {
+		$topic_format_parts = explode('/', $settings['mqtt_topic_format']);
+		$idx = array_search('%topic%', $topic_format_parts);
+		$name = $topics[$idx];
+	}
     if($name) {
-        $mqtt_found[$name]['status5']=$msg;
+        $mqtt_found[$name]['status5'] = $msg;
     }
     return;
 }

--- a/lib/mqtt.inc.php
+++ b/lib/mqtt.inc.php
@@ -41,20 +41,22 @@ function getTasmotaMQTTScan($mqtt, $topic, $user=false, $password=false, $slim=f
     }
     $mqtt->subscribe($topics, $qos = 0);
 
-	// HomeAssistant swapped
-	$mqtt->publish($topic.'/cmnd/STATUS','0');
-	if ($topic == 'tasmotas')
-		$mqtt->publish('sonoffs/cmnd/STATUS','0');
-	if (isset($settings['mqtt_topic_format'])) {
-		$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd', $topic), $settings['mqtt_topic_format']);
-		$mqtt->publish($topic_prefix . '/STATUS','0');
-		if($topic == 'tasmotas')
-			$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd','sonoffs'), $settings['mqtt_topic_format']);
-			$mqtt->publish($topic_prefix . '/STATUS','0'); 
+	if ( !$slim ) {
+		// HomeAssistant swapped
+		$mqtt->publish($topic.'/cmnd/STATUS','0');
+		if ($topic == 'tasmotas')
+			$mqtt->publish('sonoffs/cmnd/STATUS','0');
+		if (isset($settings['mqtt_topic_format'])) {
+			$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd', $topic), $settings['mqtt_topic_format']);
+			$mqtt->publish($topic_prefix . '/STATUS','0');
+			if($topic == 'tasmotas')
+				$topic_prefix = str_replace(array('%prefix%','%topic%'), array('cmnd','sonoffs'), $settings['mqtt_topic_format']);
+				$mqtt->publish($topic_prefix . '/STATUS','0'); 
+		}
+		$mqtt->publish('cmnd/'.$topic.'/STATUS','0');
+		if ($topic == 'tasmotas')
+			$mqtt->publish('cmnd/sonoffs/STATUS','0');
 	}
-	$mqtt->publish('cmnd/'.$topic.'/STATUS','0');
-	if ($topic == 'tasmotas')
-		$mqtt->publish('cmnd/sonoffs/STATUS','0');
 
 	// Default
 	$mqtt->publish($topic.'/cmnd/STATUS','5');

--- a/lib/phpMQTT.php
+++ b/lib/phpMQTT.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Bluerhinos;
+
 /*
  	phpMQTT
 	A simple php class to connect/publish/subscribe to an MQTT broker
@@ -33,63 +35,123 @@
 */
 
 /* phpMQTT */
-class phpMQTT {
 
-	private $socket; 			/* holds the socket	*/
-	private $msgid = 1;			/* counter for message id */
+class phpMQTT
+{
+	protected $socket;			/* holds the socket	*/
+	protected $msgid = 1;			/* counter for message id */
 	public $keepalive = 10;		/* default keepalive timmer */
 	public $timesinceping;		/* host unix time, used to detect disconects */
-	public $topics = array(); 	/* used to store currently subscribed topics */
+	public $topics = [];	/* used to store currently subscribed topics */
 	public $debug = false;		/* should output debug messages */
 	public $address;			/* broker address */
 	public $port;				/* broker port */
 	public $clientid;			/* client id sent to brocker */
 	public $will;				/* stores the will of the client */
-	private $username;			/* stores username */
-	private $password;			/* stores password */
+	protected $username;			/* stores username */
+	protected $password;			/* stores password */
 
 	public $cafile;
+	protected static $known_commands = [
+		1 => 'CONNECT',
+		2 => 'CONNACK',
+		3 => 'PUBLISH',
+		4 => 'PUBACK',
+		5 => 'PUBREC',
+		6 => 'PUBREL',
+		7 => 'PUBCOMP',
+		8 => 'SUBSCRIBE',
+		9 => 'SUBACK',
+		10 => 'UNSUBSCRIBE',
+		11 => 'UNSUBACK',
+		12 => 'PINGREQ',
+		13 => 'PINGRESP',
+		14 => 'DISCONNECT'
+	];
 
-	function __construct($address, $port, $clientid, $cafile = NULL){
+	/**
+	 * phpMQTT constructor.
+	 *
+	 * @param $address
+	 * @param $port
+	 * @param $clientid
+	 * @param null $cafile
+	 */
+	public function __construct($address, $port, $clientid, $cafile = null)
+	{
 		$this->broker($address, $port, $clientid, $cafile);
 	}
 
-	/* sets the broker details */
-	function broker($address, $port, $clientid, $cafile = NULL){
+	/**
+	 * Sets the broker details
+	 *
+	 * @param $address
+	 * @param $port
+	 * @param $clientid
+	 * @param null $cafile
+	 */
+	public function broker($address, $port, $clientid, $cafile = null): void
+	{
 		$this->address = $address;
 		$this->port = $port;
 		$this->clientid = $clientid;
 		$this->cafile = $cafile;
 	}
 
-	function connect_auto($clean = true, $will = NULL, $username = NULL, $password = NULL){
-		while($this->connect($clean, $will, $username, $password)==false){
+	/**
+	 * Will try and connect, if fails it will sleep 10s and try again, this will enable the script to recover from a network outage
+	 *
+	 * @param bool $clean - should the client send a clean session flag
+	 * @param null $will
+	 * @param null $username
+	 * @param null $password
+	 *
+	 * @return bool
+	 */
+	public function connect_auto($clean = true, $will = null, $username = null, $password = null): bool
+	{
+		while ($this->connect($clean, $will, $username, $password) === false) {
 			sleep(10);
 		}
 		return true;
 	}
 
-	/* connects to the broker 
-		inputs: $clean: should the client send a clean session flag */
-	function connect($clean = true, $will = NULL, $username = NULL, $password = NULL){
-		
-		if($will) $this->will = $will;
-		if($username) $this->username = $username;
-		if($password) $this->password = $password;
-
-
-		if ($this->cafile) {
-			$socketContext = stream_context_create(["ssl" => [
-				"verify_peer_name" => true,
-				"cafile" => $this->cafile
-				]]);
-			$this->socket = stream_socket_client("tls://" . $this->address . ":" . $this->port, $errno, $errstr, 60, STREAM_CLIENT_CONNECT, $socketContext);
-		} else {
-			$this->socket = stream_socket_client("tcp://" . $this->address . ":" . $this->port, $errno, $errstr, 60, STREAM_CLIENT_CONNECT);
+	/**
+	 * @param bool $clean - should the client send a clean session flag
+	 * @param null $will
+	 * @param null $username
+	 * @param null $password
+	 *
+	 * @return bool
+	 */
+	public function connect($clean = true, $will = null, $username = null, $password = null): bool
+	{
+		if ($will) {
+			$this->will = $will;
+		}
+		if ($username) {
+			$this->username = $username;
+		}
+		if ($password) {
+			$this->password = $password;
 		}
 
-		if (!$this->socket ) {
-		    if($this->debug) error_log("stream_socket_create() $errno, $errstr \n");
+		if ($this->cafile) {
+			$socketContext = stream_context_create(
+				[
+					'ssl' => [
+						'verify_peer_name' => true,
+						'cafile' => $this->cafile
+					]
+				]
+			);
+			$this->socket = stream_socket_client('tls://' . $this->address . ':' . $this->port, $errno, $errstr, 60, STREAM_CLIENT_CONNECT, $socketContext);
+		} else {
+			$this->socket = stream_socket_client('tcp://' . $this->address . ':' . $this->port, $errno, $errstr, 60, STREAM_CLIENT_CONNECT);
+		}
+
+		if (!$this->socket) {
+			$this->_errorMessage("stream_socket_create() $errno, $errstr");
 			return false;
 		}
 
@@ -97,63 +159,96 @@ class phpMQTT {
 		stream_set_blocking($this->socket, 0);
 
 		$i = 0;
-		$buffer = "";
+		$buffer = '';
 
-		$buffer .= chr(0x00); $i++;
-		$buffer .= chr(0x06); $i++;
-		$buffer .= chr(0x4d); $i++;
-		$buffer .= chr(0x51); $i++;
-		$buffer .= chr(0x49); $i++;
-		$buffer .= chr(0x73); $i++;
-		$buffer .= chr(0x64); $i++;
-		$buffer .= chr(0x70); $i++;
-		$buffer .= chr(0x03); $i++;
+		$buffer .= chr(0x00);
+		$i++; // Length MSB
+		$buffer .= chr(0x04);
+		$i++; // Length LSB
+		$buffer .= chr(0x4d);
+		$i++; // M
+		$buffer .= chr(0x51);
+		$i++; // Q
+		$buffer .= chr(0x54);
+		$i++; // T
+		$buffer .= chr(0x54);
+		$i++; // T
+		$buffer .= chr(0x04);
+		$i++; // // Protocol Level
 
 		//No Will
 		$var = 0;
-		if($clean) $var+=2;
+		if ($clean) {
+			$var += 2;
+		}
 
 		//Add will info to header
-		if($this->will != NULL){
+		if ($this->will !== null) {
 			$var += 4; // Set will flag
 			$var += ($this->will['qos'] << 3); //Set will qos
-			if($this->will['retain'])	$var += 32; //Set will retain
+			if ($this->will['retain']) {
+				$var += 32;
+			} //Set will retain
 		}
 
-		if($this->username != NULL) $var += 128;	//Add username to header
-		if($this->password != NULL) $var += 64;	//Add password to header
+		if ($this->username !== null) {
+			$var += 128;
+		}	//Add username to header
+		if ($this->password !== null) {
+			$var += 64;
+		}	//Add password to header
 
-		$buffer .= chr($var); $i++;
+		$buffer .= chr($var);
+		$i++;
 
 		//Keep alive
-		$buffer .= chr($this->keepalive >> 8); $i++;
-		$buffer .= chr($this->keepalive & 0xff); $i++;
+		$buffer .= chr($this->keepalive >> 8);
+		$i++;
+		$buffer .= chr($this->keepalive & 0xff);
+		$i++;
 
-		$buffer .= $this->strwritestring($this->clientid,$i);
+		$buffer .= $this->strwritestring($this->clientid, $i);
 
 		//Adding will to payload
-		if($this->will != NULL){
-			$buffer .= $this->strwritestring($this->will['topic'],$i);  
-			$buffer .= $this->strwritestring($this->will['content'],$i);
+		if ($this->will !== null) {
+			$buffer .= $this->strwritestring($this->will['topic'], $i);
+			$buffer .= $this->strwritestring($this->will['content'], $i);
 		}
 
-		if($this->username) $buffer .= $this->strwritestring($this->username,$i);
-		if($this->password) $buffer .= $this->strwritestring($this->password,$i);
+		if ($this->username !== null) {
+			$buffer .= $this->strwritestring($this->username, $i);
+		}
+		if ($this->password !== null) {
+			$buffer .= $this->strwritestring($this->password, $i);
+		}
 
-		$head = "  ";
-		$head{0} = chr(0x10);
-		$head{1} = chr($i);
+		$head = chr(0x10);
+
+		while ($i > 0) {
+			$encodedByte = $i % 128;
+			$i /= 128;
+			$i = (int)$i;
+			if ($i > 0) {
+				$encodedByte |= 128;
+			}
+			$head .= chr($encodedByte);
+		}
 
 		fwrite($this->socket, $head, 2);
-		fwrite($this->socket,  $buffer);
+		fwrite($this->socket, $buffer);
 
-	 	$string = $this->read(4);
+		$string = $this->read(4);
 
-		if(ord($string{0})>>4 == 2 && $string{3} == chr(0)){
-			if($this->debug) echo "Connected to Broker\n"; 
-		}else{	
-			error_log(sprintf("Connection failed! (Error: 0x%02x 0x%02x)\n", 
-			                        ord($string{0}),ord($string{3})));
+		if (ord($string[0]) >> 4 === 2 && $string[3] === chr(0)) {
+			$this->_debugMessage('Connected to Broker');
+		} else {
+			$this->_errorMessage(
+				sprintf(
+					"Connection failed! (Error: 0x%02x 0x%02x)\n",
+					ord($string[0]),
+					ord($string[3])
+				)
+			);
 			return false;
 		}
 
@@ -162,263 +257,416 @@ class phpMQTT {
 		return true;
 	}
 
-	/* read: reads in so many bytes */
-	function read($int = 8192, $nb = false){
-
-		//	print_r(socket_get_status($this->socket));
-		
-		$string="";
+	/**
+	 * Reads in so many bytes
+	 *
+	 * @param int $int
+	 * @param bool $nb
+	 *
+	 * @return false|string
+	 */
+	public function read($int = 8192, $nb = false)
+	{
+		$string = '';
 		$togo = $int;
-		
-		if($nb){
+
+		if ($nb) {
 			return fread($this->socket, $togo);
 		}
-			
-		while (!feof($this->socket) && $togo>0) {
+
+		while (!feof($this->socket) && $togo > 0) {
 			$fread = fread($this->socket, $togo);
 			$string .= $fread;
 			$togo = $int - strlen($string);
 		}
-		
-	
-		
-		
-			return $string;
+
+		return $string;
 	}
 
-	/* subscribe: subscribes to topics */
-	function subscribe($topics, $qos = 0){
-		$i = 0;
-		$buffer = "";
-		$id = $this->msgid;
-		$buffer .= chr($id >> 8);  $i++;
-		$buffer .= chr($id % 256);  $i++;
+	/**
+	 * Subscribes to a topic, wait for message and return it
+	 *
+	 * @param $topic
+	 * @param $qos
+	 *
+	 * @return string
+	 */
+	public function subscribeAndWaitForMessage($topic, $qos): string
+	{
+		$this->subscribe(
+			[
+				$topic => [
+					'qos' => $qos,
+					'function' => '__direct_return_message__'
+				]
+			]
+		);
 
-		foreach($topics as $key => $topic){
-			$buffer .= $this->strwritestring($key,$i);
-			$buffer .= chr($topic["qos"]);  $i++;
-			$this->topics[$key] = $topic; 
+		do {
+			$return = $this->proc();
+		} while ($return === true);
+
+		return $return;
+	}
+
+	/**
+	 * subscribes to topics
+	 *
+	 * @param $topics
+	 * @param int $qos
+	 */
+	public function subscribe($topics, $qos = 0): void
+	{
+		$i = 0;
+		$buffer = '';
+		$id = $this->msgid;
+		$buffer .= chr($id >> 8);
+		$i++;
+		$buffer .= chr($id % 256);
+		$i++;
+
+		foreach ($topics as $key => $topic) {
+			$buffer .= $this->strwritestring($key, $i);
+			$buffer .= chr($topic['qos']);
+			$i++;
+			$this->topics[$key] = $topic;
 		}
 
-		$cmd = 0x80;
+		$cmd = 0x82;
 		//$qos
-		$cmd +=	($qos << 1);
-
+		$cmd += ($qos << 1);
 
 		$head = chr($cmd);
-		$head .= chr($i);
-		
-		fwrite($this->socket, $head, 2);
-		fwrite($this->socket, $buffer, $i);
+		$head .= $this->setmsglength($i);
+		fwrite($this->socket, $head, strlen($head));
+
+		$this->_fwrite($buffer);
 		$string = $this->read(2);
-		
-		$bytes = ord(substr($string,1,1));
-		$string = $this->read($bytes);
+
+		$bytes = ord(substr($string, 1, 1));
+		$this->read($bytes);
 	}
 
-	/* ping: sends a keep alive ping */
-	function ping(){
-			$head = " ";
-			$head = chr(0xc0);		
-			$head .= chr(0x00);
-			fwrite($this->socket, $head, 2);
-			if($this->debug) echo "ping sent\n";
+	/**
+	 * Sends a keep alive ping
+	 */
+	public function ping(): void
+	{
+		$head = chr(0xc0);
+		$head .= chr(0x00);
+		fwrite($this->socket, $head, 2);
+		$this->timesinceping = time();
+		$this->_debugMessage('ping sent');
 	}
 
-	/* disconnect: sends a proper disconect cmd */
-	function disconnect(){
-			$head = " ";
-			$head{0} = chr(0xe0);		
-			$head{1} = chr(0x00);
-			fwrite($this->socket, $head, 2);
+	/**
+	 *  sends a proper disconnect cmd
+	 */
+	public function disconnect(): void
+	{
+		$head = ' ';
+		$head[0] = chr(0xe0);
+		$head[1] = chr(0x00);
+		fwrite($this->socket, $head, 2);
 	}
 
-	/* close: sends a proper disconect, then closes the socket */
-	function close(){
-	 	$this->disconnect();
-		stream_socket_shutdown($this->socket, STREAM_SHUT_WR);	
+	/**
+	 * Sends a proper disconnect, then closes the socket
+	 */
+	public function close(): void
+	{
+		$this->disconnect();
+		stream_socket_shutdown($this->socket, STREAM_SHUT_WR);
 	}
 
-	/* publish: publishes $content on a $topic */
-	function publish($topic, $content, $qos = 0, $retain = 0){
-
+	/**
+	 * Publishes $content on a $topic
+	 *
+	 * @param $topic
+	 * @param $content
+	 * @param int $qos
+	 * @param bool $retain
+	 */
+	public function publish($topic, $content, $qos = 0, $retain = false): void
+	{
 		$i = 0;
-		$buffer = "";
+		$buffer = '';
 
-		$buffer .= $this->strwritestring($topic,$i);
+		$buffer .= $this->strwritestring($topic, $i);
 
-		//$buffer .= $this->strwritestring($content,$i);
-
-		if($qos){
+		if ($qos) {
 			$id = $this->msgid++;
-			$buffer .= chr($id >> 8);  $i++;
-		 	$buffer .= chr($id % 256);  $i++;
+			$buffer .= chr($id >> 8);
+			$i++;
+			$buffer .= chr($id % 256);
+			$i++;
 		}
 
 		$buffer .= $content;
-		$i+=strlen($content);
+		$i += strlen($content);
 
-
-		$head = " ";
+		$head = ' ';
 		$cmd = 0x30;
-		if($qos) $cmd += $qos << 1;
-		if($retain) $cmd += 1;
+		if ($qos) {
+			$cmd += $qos << 1;
+		}
+		if (empty($retain) === false) {
+			++$cmd;
+		}
 
-		$head{0} = chr($cmd);		
+		$head[0] = chr($cmd);
 		$head .= $this->setmsglength($i);
 
 		fwrite($this->socket, $head, strlen($head));
-		fwrite($this->socket, $buffer, $i);
-
+		$this->_fwrite($buffer);
 	}
 
-	/* message: processes a recieved topic */
-	function message($msg){
-		 	$tlen = (ord($msg{0})<<8) + ord($msg{1});
-			$topic = substr($msg,2,$tlen);
-			$msg = substr($msg,($tlen+2));
-			$found = 0;
-			foreach($this->topics as $key=>$top){
-				if( preg_match("/^".str_replace("#",".*",
-						str_replace("+","[^\/]*",
-							str_replace("/","\/",
-								str_replace("$",'\$',
-									$key))))."$/",$topic) ){
-					if(is_callable($top['function'])){
-						call_user_func($top['function'],$topic,$msg);
-						$found = 1;
-					}
-				}
+	/**
+	 * Writes a string to the socket
+	 *
+	 * @param $buffer
+	 *
+	 * @return bool|int
+	 */
+	protected function _fwrite($buffer)
+	{
+		$buffer_length = strlen($buffer);
+		for ($written = 0; $written < $buffer_length; $written += $fwrite) {
+			$fwrite = fwrite($this->socket, substr($buffer, $written));
+			if ($fwrite === false) {
+				return false;
 			}
-
-			if($this->debug && !$found) echo "msg recieved but no match in subscriptions\n";
-	}
-
-	/* proc: the processing loop for an "allways on" client 
-		set true when you are doing other stuff in the loop good for watching something else at the same time */	
-	function proc( $loop = true){
-
-		if(1){
-			$sockets = array($this->socket);
-			$w = $e = NULL;
-			$cmd = 0;
-			
-				//$byte = fgetc($this->socket);
-			if(feof($this->socket)){
-				if($this->debug) echo "eof receive going to reconnect for good measure\n";
-				fclose($this->socket);
-				$this->connect_auto(false);
-				if(count($this->topics))
-					$this->subscribe($this->topics);	
-			}
-			
-			$byte = $this->read(1, true);
-			
-			if(!strlen($byte)){
-				if($loop){
-					usleep(100000);
-					return true;
-				} else
-					return false;
-			 
-			}else{ 
-			
-				$cmd = (int)(ord($byte)/16);
-				if($this->debug) echo "Recevid: $cmd\n";
-
-				$multiplier = 1; 
-				$value = 0;
-				do{
-					$digit = ord($this->read(1));
-					$value += ($digit & 127) * $multiplier; 
-					$multiplier *= 128;
-					}while (($digit & 128) != 0);
-
-				if($this->debug) echo "Fetching: $value\n";
-				
-				if($value)
-					$string = $this->read($value);
-				
-				if($cmd){
-					switch($cmd){
-						case 3:
-							$this->message($string);
-						break;
-					}
-
-					$this->timesinceping = time();
-				}
-			}
-
-			if($this->timesinceping < (time() - $this->keepalive )){
-				if($this->debug) echo "not found something so ping\n";
-				$this->ping();	
-			}
-			
-
-			if($this->timesinceping<(time()-($this->keepalive*2))){
-				if($this->debug) echo "not seen a package in a while, disconnecting\n";
-				fclose($this->socket);
-				$this->connect_auto(false);
-				if(count($this->topics))
-					$this->subscribe($this->topics);
-			}
-			return true;
-
 		}
-		return false;
+		return $buffer_length;
 	}
 
-	/* getmsglength: */
-	function getmsglength(&$msg, &$i){
+	/**
+	 * Processes a received topic
+	 *
+	 * @param $msg
+	 *
+	 * @retrun bool|string
+	 */
+	public function message($msg)
+	{
+		$tlen = (ord($msg{0}) << 8) + ord($msg[1]);
+		$topic = substr($msg, 2, $tlen);
+		$msg = substr($msg, ($tlen + 2));
+		$found = false;
+		foreach ($this->topics as $key => $top) {
+			if (preg_match(
+				'/^' . str_replace(
+					'#',
+					'.*',
+					str_replace(
+						'+',
+						"[^\/]*",
+						str_replace(
+							'/',
+							"\/",
+							str_replace(
+								'$',
+								'\$',
+								$key
+							)
+						)
+					)
+				) . '$/',
+				$topic
+			)) {
+				if ($top['function'] === '__direct_return_message__') {
+					return $msg;
+				}
 
-		$multiplier = 1; 
-		$value = 0 ;
-		do{
-		  $digit = ord($msg{$i});
-		  $value += ($digit & 127) * $multiplier; 
-		  $multiplier *= 128;
-		  $i++;
-		}while (($digit & 128) != 0);
+				if (is_callable($top['function'])) {
+					call_user_func($top['function'], $topic, $msg);
+				} else {
+					$this->_errorMessage('Message received on topic ' . $topic. ' but function is not callable.');
+				}
+				$found = true;
+			}
+		}
+
+		if ($found === false) {
+			$this->_debugMessage('msg received but no match in subscriptions');
+		} else {
+			$this->_debugMessage('msg received that matched a subscribed topic');
+		}
+
+		return $found;
+	}
+
+	/**
+	 * The processing loop for an "always on" client
+	 * set true when you are doing other stuff in the loop good for
+	 * watching something else at the same time
+	 *
+	 * @param bool $loop
+	 *
+	 * @return bool | string
+	 */
+	public function proc(bool $loop = true)
+	{
+		if (feof($this->socket)) {
+			$this->_debugMessage('eof receive going to reconnect for good measure');
+			fclose($this->socket);
+			$this->connect_auto(false);
+			if (count($this->topics)) {
+				$this->subscribe($this->topics);
+			}
+		}
+
+		$byte = $this->read(1, true);
+
+		if ((string)$byte === '') {
+			if ($loop === true) {
+				usleep(100000);
+			}
+		} else {
+			$cmd = (int)(ord($byte) / 16);
+			$this->_debugMessage(
+				sprintf(
+					'Received CMD: %d (%s)',
+					$cmd,
+					isset(static::$known_commands[$cmd]) === true ? static::$known_commands[$cmd] : 'Unknown'
+				)
+			);
+
+			$multiplier = 1;
+			$value = 0;
+			do {
+				$digit = ord($this->read(1));
+				$value += ($digit & 127) * $multiplier;
+				$multiplier *= 128;
+			} while (($digit & 128) !== 0);
+
+			$this->_debugMessage('Fetching: ' . $value . ' bytes');
+
+			$string = $value > 0 ? $this->read($value) : '';
+
+			if ($cmd) {
+				switch ($cmd) {
+					case 3: //Publish MSG
+						$return = $this->message($string);
+						if (is_bool($return) === false) {
+							return $return;
+						}
+						break;
+				}
+			}
+		}
+
+		if ($this->timesinceping < (time() - $this->keepalive)) {
+			$this->_debugMessage('not had something in a while so ping');
+			$this->ping();
+		}
+
+		if ($this->timesinceping < (time() - ($this->keepalive * 2))) {
+			$this->_debugMessage('not seen a packet in a while, disconnecting/reconnecting');
+			fclose($this->socket);
+			$this->connect_auto(false);
+			if (count($this->topics)) {
+				$this->subscribe($this->topics);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the length of a msg, (and increments $i)
+	 *
+	 * @param $msg
+	 * @param $i
+	 *
+	 * @return float|int
+	 */
+	protected function getmsglength(&$msg, &$i)
+	{
+		$multiplier = 1;
+		$value = 0;
+		do {
+			$digit = ord($msg[$i]);
+			$value += ($digit & 127) * $multiplier;
+			$multiplier *= 128;
+			$i++;
+		} while (($digit & 128) !== 0);
 
 		return $value;
 	}
 
-
-	/* setmsglength: */
-	function setmsglength($len){
-		$string = "";
-		do{
-		  $digit = $len % 128;
-		  $len = $len >> 7;
-		  // if there are more digits to encode, set the top bit of this digit
-		  if ( $len > 0 )
-		    $digit = ($digit | 0x80);
-		  $string .= chr($digit);
-		}while ( $len > 0 );
+	/**
+	 * @param $len
+	 *
+	 * @return string
+	 */
+	protected function setmsglength($len): string
+	{
+		$string = '';
+		do {
+			$digit = $len % 128;
+			$len >>= 7;
+			// if there are more digits to encode, set the top bit of this digit
+			if ($len > 0) {
+				$digit |= 0x80;
+			}
+			$string .= chr($digit);
+		} while ($len > 0);
 		return $string;
 	}
 
-	/* strwritestring: writes a string to a buffer */
-	function strwritestring($str, &$i){
-		$ret = " ";
+	/**
+	 * @param $str
+	 * @param $i
+	 *
+	 * @return string
+	 */
+	protected function strwritestring($str, &$i): string
+	{
 		$len = strlen($str);
 		$msb = $len >> 8;
 		$lsb = $len % 256;
 		$ret = chr($msb);
 		$ret .= chr($lsb);
 		$ret .= $str;
-		$i += ($len+2);
+		$i += ($len + 2);
 		return $ret;
 	}
 
-	function printstr($string){
+	/**
+	 * Prints a sting out character by character
+	 *
+	 * @param $string
+	 */
+	public function printstr($string): void
+	{
 		$strlen = strlen($string);
-			for($j=0;$j<$strlen;$j++){
-				$num = ord($string{$j});
-				if($num > 31) 
-					$chr = $string{$j}; else $chr = " ";
-				printf("%4d: %08b : 0x%02x : %s \n",$j,$num,$num,$chr);
+		for ($j = 0; $j < $strlen; $j++) {
+			$num = ord($string[$j]);
+			if ($num > 31) {
+				$chr = $string[$j];
+			} else {
+				$chr = ' ';
 			}
+			printf("%4d: %08b : 0x%02x : %s \n", $j, $num, $num, $chr);
+		}
+	}
+
+	/**
+	 * @param string $message
+	 */
+	protected function _debugMessage(string $message): void
+	{
+		if ($this->debug === true) {
+			echo date('r: ') . $message . PHP_EOL;
+		}
+	}
+
+	/**
+	 * @param string $message
+	 */
+	protected function _errorMessage(string $message): void
+	{
+		error_log('Error:' . $message);
 	}
 }


### PR DESCRIPTION
I found that the code didn't work when I had a "MQTT Topic Format" value populated in the settings.
Mine is `tasmota/%topic%/%prefix%`

The `lib/mqtt.inc.php` wasn't working, but I think there was a problem with the `phpMQTT.php` library.
So, I updated that and also then amended the `mqtt.inc.php` subscribe functions to handle the "MQTT Topic Format".  There was a condition missing for the "name".

There was some updates on the [phpMQTT.php library](https://github.com/bluerhinos/phpMQTT), and this version worked for me - so I included a copy of that version in this pull request.