### PR TITLE
adding in firmware version on main index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -154,6 +154,8 @@ $(document).ready(function() {
     </thead>
     <tbody>
 <?php
+	$github_tasmota_release_data = getGithubTasmotaReleaseData();
+
     $list_model='';
     $now=time();
     $lastbackup_green=0;
@@ -210,8 +212,22 @@ $(document).ready(function() {
             $ver=substr($version,0,$pos);
             $tag=substr($version,$pos);
             $version=$ver.' <small>'.$tag.'</small>';
+
+			$release_html_url = "";
+			if ( $tag == "(tasmota)" ) {
+				$github_tag_name = 'v' . $ver;
+				foreach ( $github_tasmota_release_data as $release => $values ) {
+					$release_html_url = $values['html_url'];
+					if ( $values['tag_name'] == $github_tag_name ) {
+						break;
+					}
+				}
+			} else {
+				// default to the Tasmota documentation if a custom "version" is in use
+				$release_html_url = "https://tasmota.github.io/docs/";
+			}
         }
-	echo "</center></td><td><center>" . $version . "</center></td><td $color><center>" . $lastbackup . "</center></td>";
+	echo "</center></td><td><center><a href='" . $release_html_url . "'>" . $version . "</a></center></td><td $color><center>" . $lastbackup . "</center></td>";
 	echo "<td><center><form method='POST' action='listbackups.php'><input type='hidden' value='" . $name . "' name='name'><input type='hidden' value='" . $id . "' name='id'><input type='submit' value='" . $numberofbackups . "' class='btn-xs btn-info'></form></center></td>";
 	echo "<td><center><form method='POST' action='index.php'><input type='hidden' value='" . $ip . "' name='ip'><input type='hidden' value='singlebackup' name='task'><input type='submit' value='Backup' class='btn-xs btn-success'></form></center></td>";
 	echo "<td><center><form method='POST' action='edit.php'><input type='hidden' value='" . $ip . "' name='ip'><input type='hidden' value='" . $name . "' name='name'><input type='hidden' value='edit' name='task'><input type='submit' value='Edit' class='btn-xs btn-warning'></form></center></td>";

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -544,3 +544,43 @@ function TBFooter()
 <?php
 }
 
+function getGithubTasmotaReleaseData()
+{
+    global $settings;
+
+	// put the releases json in the backup_folder
+    $backupfolder = $settings['backup_folder'];
+	$get_new_version = false;
+
+	$github_tasmota_release_data_file = $backupfolder . "/github-tasmota-release-data.json";
+	// check if file exists
+	if ( file_exists($github_tasmota_release_data_file) === true ) {
+		$_mtime = filemtime($github_tasmota_release_data_file);
+		$yesterday = strtotime("-1 days");
+		if ( $_mtime <= $yesterday ) {
+			$get_new_version = true;
+		}
+	} else {
+		$get_new_version = true;
+	}
+
+	if ( $get_new_version ) {
+		// get Tasmota release data from github - but only if it is the next calendar day
+		$opts = [
+			'http' => [
+				'method' => 'GET',
+				'header' => [
+					'User-Agent: PHP'
+				]
+			]
+		];
+		$context = stream_context_create($opts);
+		$github_tasmota_version_release_details = file_get_contents("https://api.github.com/repos/arendst/Tasmota/releases", false, $context);
+		file_put_contents($github_tasmota_release_data_file, $github_tasmota_version_release_details);
+	} else {
+		$github_tasmota_version_release_details = file_get_contents($github_tasmota_release_data_file);
+	}
+	$github_tasmota_release_data = json_decode($github_tasmota_version_release_details, true);
+
+	return $github_tasmota_release_data;
+}


### PR DESCRIPTION
Saw this [feature request](https://github.com/danmed/TasmoBackupV1/issues/32) and thought I would give it a go.
This pull request contains the code to get the github release information and display it as a link on the main index page of TasmoBackup.
![image](https://user-images.githubusercontent.com/5875512/123622678-df948280-d84f-11eb-80ef-587841c7c54a.png)
