### PR TITLE
Replace intval with native typecast

### DIFF
--- a/index.php
+++ b/index.php
@@ -59,8 +59,8 @@ switch(strtolower($task)) {
         }
         break;
     case 'download':
-        $device=dbDeviceId(intval($_POST["id"]));
-        $backup=dbBackupId(intval($_POST["backupid"]));
+        $device=dbDeviceId((int)$_POST["id"]);
+        $backup=dbBackupId((int)$_POST["backupid"]);
         downloadTasmotaBackup($backup);
         break;
     case 'singlebackup':
@@ -174,8 +174,8 @@ $(document).ready(function() {
     $lastbackup_red=0;
     $lastbackup_yellow=0;
     if(isset($settings['backup_minhours']) && $settings['backup_minhours']>0) {
-        $lastbackup_green=$now-(intval($settings['backup_minhours'])*3600*2.2);
-        $lastbackup_red=$now-(intval($settings['backup_minhours'])*3600*8);
+        $lastbackup_green=$now-((int)$settings['backup_minhours'] *3600*2.2);
+        $lastbackup_red=$now-((int)$settings['backup_minhours'] *3600*8);
     }    
     $devices = dbDevicesSort();
     foreach ($devices as $db_field) {
@@ -191,7 +191,7 @@ $(document).ready(function() {
         }
         $logo='images/tasmota.png';
         $type='Tasmota';
-        if(isset($db_field['type']) && intval($db_field['type'])===1) {
+        if(isset($db_field['type']) && (int)$db_field['type'] ===1) {
             $logo='images/wled.png';
             $type='WLED';
         }

--- a/lib/db.inc.php
+++ b/lib/db.inc.php
@@ -150,7 +150,7 @@ function dbBackupList($id,$days=0)
 {
     global $db_handle;
 
-    $days=intval($days);
+    $days= (int)$days;
     $datecond='';
     if($days>0) {
         $date = date('Y-m-d H:i:s',time()-(86400*$days));
@@ -180,8 +180,8 @@ function dbBackupTrim($id,$days,$count,$all=false)
 {
     global $db_handle;
 
-    $days=intval($days);
-    $count=intval($count);
+    $days= (int)$days;
+    $count= (int)$count;
     if($days==0 && $count==0 && !$all)
         return true;
 
@@ -278,7 +278,7 @@ function dbDeviceDel($ip)
     $stm->bindValue(':ip', $ip, PDO::PARAM_STR);
     if (!$stm->execute())
         return false;
-    $id=intval($stm->fetchColumn());
+    $id= (int)$stm->fetchColumn();
     if($id==0)
         return false;
     dbBackupTrim($id,0,0,true);
@@ -427,14 +427,14 @@ if ($GLOBALS['DBType']=='mysql') {
 
     $stm=$db_handle->prepare("SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='".$GLOBALS['DBName']."' AND TABLE_NAME='devices' AND COLUMN_NAME='mac';");
     $stm->execute();
-    $cnt=intval($stm->fetchColumn());
+    $cnt= (int)$stm->fetchColumn();
     if($cnt<1) {
         $db_handle->exec("ALTER TABLE devices ADD COLUMN mac varchar(32) NOT NULL DEFAULT '' AFTER ip;");
     }
 
     $stm=$db_handle->prepare("SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='".$GLOBALS['DBName']."' AND TABLE_NAME='devices' AND COLUMN_NAME='type';");
     $stm->execute();
-    $cnt=intval($stm->fetchColumn());
+    $cnt= (int)$stm->fetchColumn();
     if($cnt<1) {
         $db_handle->exec("ALTER TABLE devices ADD COLUMN type int(3) NOT NULL DEFAULT 0 AFTER mac;");
     }

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -165,7 +165,7 @@ function getTasmotaStatus($ip, $user, $password, $type=0)
 {
     //Get Name
     $url = 'http://' .rawurlencode($user).':'.rawurlencode($password).'@'. $ip . '/cm?cmnd=status%200&user='.rawurlencode($user).'&password=' . rawurlencode($password);
-    if(intval($type)===1)
+    if((int)$type ===1)
         $url = 'http://' .rawurlencode($user).':'.rawurlencode($password).'@'. $ip . '/json';
     $options = array(
         CURLOPT_FOLLOWLOCATION => false,
@@ -332,7 +332,7 @@ function getTasmotaBackup($ip, $user, $password, $filename, $type=0)
 {
     //Get Backup
 
-    if(intval($type)===0) { // Tasmota
+    if((int)$type ===0) { // Tasmota
         $fp = fopen($filename, 'w+');
         if ($fp === false) {
             return false;
@@ -360,7 +360,7 @@ function getTasmotaBackup($ip, $user, $password, $filename, $type=0)
         if (!$err && $statusCode == 200) {
             return true;
         }
-    } else if(intval($type)===1) { // WLED
+    } else if((int)$type ===1) { // WLED
         $url = 'http://'.rawurlencode($user).':'.rawurlencode($password)."@".$ip.'/edit?download=cfg.json';
         $options = array(
             CURLOPT_FOLLOWLOCATION => false,
@@ -414,9 +414,9 @@ function backupCleanup($id)
     $days=0;
     $count=0;
     if(isset($settings['backup_maxdays']))
-        $days=intval($settings['backup_maxdays']);
+        $days= (int)$settings['backup_maxdays'];
     if(isset($settings['backup_maxcount']))
-        $count=intval($settings['backup_maxcount']);
+        $count= (int)$settings['backup_maxcount'];
     if($days>0 || $count>0)
         return dbBackupTrim($id,$days,$count);
     return true;
@@ -429,7 +429,7 @@ function backupSingle($id, $name, $ip, $user, $password, $type=0)
     $backupfolder = $settings['backup_folder'];
 
     if ($status=getTasmotaStatus($ip, $user, $password, $type)) {
-        if(intval($type)===0) { // Tasmota
+        if((int)$type ===0) { // Tasmota
             if (!isset($status['StatusFWR'])) {
                 sleep(1);
                 if ($status2=getTasmotaStatus2($ip, $user, $password)) {
@@ -445,7 +445,7 @@ function backupSingle($id, $name, $ip, $user, $password, $type=0)
                     return true; // Device Offline
             }
         }
-        if(intval($type)===1) { // WLED
+        if((int)$type ===1) { // WLED
             if (!isset($status['info']['ver']))
                 return true;
         }
@@ -453,7 +453,7 @@ function backupSingle($id, $name, $ip, $user, $password, $type=0)
         return true; // Device Offline
     }
 
-    if(intval($type)===0) { // Tasmota
+    if((int)$type ===0) { // Tasmota
         $version = $status['StatusFWR']['Version'];
         $mac = strtoupper($status['StatusNET']['Mac']);
 
@@ -471,7 +471,7 @@ function backupSingle($id, $name, $ip, $user, $password, $type=0)
                 }
             }
         }
-    } else if (intval($type)===1) { // WLED
+    } else if ((int)$type ===1) { // WLED
         if(isset($status['info']['name']))
             $name=trim($status['info']['name']);
         if(isset($status['info']['ver']))
@@ -493,7 +493,7 @@ function backupSingle($id, $name, $ip, $user, $password, $type=0)
     $savedate = preg_replace('/[^A-Za-z0-9_\-]/', '', $savedate);
 
     $ext='.dmp';
-    if(intval($type)===1) $ext='.zip';
+    if((int)$type ===1) $ext='.zip';
 
 
     $saveto = $backupfolder . $savename . "/" . $savemac . "-" . $savedate . $ext;
@@ -527,7 +527,7 @@ function backupAll($docker=false)
 
     $hours=0;
     if(isset($settings['backup_minhours']))
-        $hours=intval($settings['backup_minhours']);
+        $hours= (int)$settings['backup_minhours'];
     if($docker && $hours==0)
         return false;
     if ($docker && isset($settings['autoadd_scan']) && $settings['autoadd_scan']=='Y') { // auto scan on schedule
@@ -569,7 +569,7 @@ function addTasmotaDevice($ip, $user, $password, $verified=false, $status=false,
         if ($status===false)
             $status=getTasmotaStatus($ip, $user, $password, $type);
         if (isset($status) && $status) {
-            if(intval($type)===0) { // Tasmota
+            if((int)$type ===0) { // Tasmota
                 if (!isset($status['StatusNET'])) {
                     sleep(1);
                     if ($status5=getTasmotaStatus5($ip, $user, $password))
@@ -600,7 +600,7 @@ function addTasmotaDevice($ip, $user, $password, $verified=false, $status=false,
                     $version=$status['StatusFWR']['Version'];
                 if (isset($status['StatusNET']['Mac']))
                     $mac=strtoupper($status['StatusNET']['Mac']);
-            } else if (intval($type)===1) { // WLED
+            } else if ((int)$type ===1) { // WLED
                 if(isset($status['info']['name']))
                     $name=trim($status['info']['name']);
                 if(isset($status['info']['ver']))
@@ -625,7 +625,7 @@ function addTasmotaDevice($ip, $user, $password, $verified=false, $status=false,
         return $ip.': Device not responding to status request.';
     } else { // Update device metadata, but only if scanned via mqtt as not to add more overhead
         if (isset($status) && $status) {
-            if(intval($type)===0) {
+            if((int)$type ===0) {
                 if(isset($settings['use_topic_as_name']) && $settings['use_topic_as_name']=='F' && isset($status['Topic'])) {
                     $name=trim(str_replace(array('/stat','stat/'),array('',''),$status['Topic'])," \t\r\n\v\0/");;
                 } else {
@@ -642,7 +642,7 @@ function addTasmotaDevice($ip, $user, $password, $verified=false, $status=false,
                     $version=$status['StatusFWR']['Version'];
                 if (isset($status['StatusNET']['Mac']))
                     $mac=strtoupper($status['StatusNET']['Mac']);
-            } else if (intval($type)===1) { // WLED
+            } else if ((int)$type ===1) { // WLED
                 if(isset($status['info']['name']))
                     $name=trim($status['info']['name']);
                 if(isset($status['info']['ver']))

--- a/listbackups.php
+++ b/listbackups.php
@@ -8,17 +8,17 @@ if (isset($_POST["name"])) {
     $name = $_POST["name"];
 }
 if (isset($_POST["id"])) {
-    $id = intval($_POST["id"]);
+    $id = (int)$_POST["id"];
 }
 if (isset($_POST["task"])) {
     switch(strtolower($_POST["task"])) {
         case 'delbackup':
-            dbBackupDel(intval($_POST["backupid"]));
+            dbBackupDel((int)$_POST["backupid"]);
             dbDeviceBackups($id);
             break;
         case 'restorebackup':
             $device=dbDeviceId($id);
-            $backup=dbBackupId(intval($_POST["backupid"]));
+            $backup=dbBackupId((int)$_POST["backupid"]);
             restoreTasmotaBackup($device['ip'],'admin',$device['password'],$backup['filename']);
             break;
     }
@@ -52,7 +52,7 @@ $(document).ready(function() {
     $device = dbDeviceId($id);
     $type=0;
     if(isset($device['type']))
-        $type=intval($device['type']);
+        $type= (int)$device['type'];
 
     $backups = dbBackupList($id);
     foreach ($backups as $db_field) {
@@ -90,7 +90,7 @@ $(document).ready(function() {
     </form>
   </center></td>
 <?php
-        if(intval($type)===0) {
+        if((int)$type===0) {
 ?>  <td><center>
     <form action='listbackups.php' method='POST'>
     <input type='hidden' name='task' value='restorebackup'>

--- a/settings.php
+++ b/settings.php
@@ -6,17 +6,17 @@ global $db_handle;
 global $settings;
 
 if (isset($_POST["sortoption"])) {
-    dbSettingsUpdate('sort',intval($_POST["sortoption"]));
+    dbSettingsUpdate('sort', (int)$_POST["sortoption"]);
 }
 
 if (isset($_POST["amountoption"])) {
-    dbSettingsUpdate('amount',intval($_POST["amountoption"]));
+    dbSettingsUpdate('amount', (int)$_POST["amountoption"]);
 }
 if (isset($_POST['mqtt_host'])) {
     dbSettingsUpdate('mqtt_host',$_POST['mqtt_host']);
 }
 if (isset($_POST['mqtt_port'])) {
-    dbSettingsUpdate('mqtt_port',intval($_POST['mqtt_port']));
+    dbSettingsUpdate('mqtt_port', (int)$_POST['mqtt_port']);
 }
 if (isset($_POST['mqtt_user'])) {
     dbSettingsUpdate('mqtt_user',$_POST['mqtt_user']);
@@ -31,13 +31,13 @@ if (isset($_POST['mqtt_topic_format'])) {
     dbSettingsUpdate('mqtt_topic_format',trim($_POST['mqtt_topic_format']," \t\n\r\0\v/"));
 }
 if (isset($_POST['backup_minhours'])) {
-    dbSettingsUpdate('backup_minhours',intval($_POST['backup_minhours']));
+    dbSettingsUpdate('backup_minhours', (int)$_POST['backup_minhours']);
 }
 if (isset($_POST['backup_maxdays'])) {
-    dbSettingsUpdate('backup_maxdays',intval($_POST['backup_maxdays']));
+    dbSettingsUpdate('backup_maxdays', (int)$_POST['backup_maxdays']);
 }
 if (isset($_POST['backup_maxcount'])) {
-    dbSettingsUpdate('backup_maxcount',intval($_POST['backup_maxcount']));
+    dbSettingsUpdate('backup_maxcount', (int)$_POST['backup_maxcount']);
 }
 if (isset($_POST['backup_folder'])) {
     dbSettingsUpdate('backup_folder',$_POST['backup_folder']);


### PR DESCRIPTION
Hey @danmed, 
I'm using your addon quite a while and would like to contribute.

In this PR I replaced the intval calls with the native typecast (int). Typecasts is more performant, best practice in PHP development and they reduce the processing load. 

If you have any questions regarding my changes feel free to ping me. 

Cheers Patrick