### PR TITLE
Add GET request to set upload_file_type in restoreTasmotaBackup

### DIFF
--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -279,6 +279,12 @@ function getTasmotaStatus5($ip, $user, $password)
 
 function restoreTasmotaBackup($ip, $user, $password, $filename)
 {
+    // GET /rs first to set upload_file_type=UPL_SETTINGS on the device
+    $rs = curl_init('http://'.rawurlencode($user).':'.rawurlencode($password)."@".$ip.'/rs');
+    curl_setopt_array($rs, array(CURLOPT_RETURNTRANSFER => true, CURLOPT_TIMEOUT => 10));
+    curl_exec($rs);
+    curl_close($rs);
+	
     $url = 'http://'.rawurlencode($user).':'.rawurlencode($password)."@".$ip.'/u2';
 
     $cfile = new CURLFile($filename,'application/octet-stream','config.dmp');


### PR DESCRIPTION
Added a preliminary GET request to set upload_file_type for Tasmota backup restoration.
Fixes #69